### PR TITLE
Remove App::Prove6 installation from GitHub action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,5 @@ jobs:
             - name: Install dependencies
               run: |
                 zef install --/test --deps-only .
-                zef install --/test App::Prove6
             - name: Run tests
               run: zef test .


### PR DESCRIPTION
This is because it's unnecessary for `zef test .` to work and was only
included due to historical reasons.  More info in this comment:
https://github.com/perl6/Pod-To-Cached/commit/58a2752178cefb04abf177a9f62b83e58886a486#r41073716.